### PR TITLE
set up DBContext

### DIFF
--- a/ClothingStoreApp/ClothingStore.API/appsettings.json
+++ b/ClothingStoreApp/ClothingStore.API/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=DESKTOP-ECILTJV;Initial Catalog=Clothing_Database;Integrated Security=True;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False",
+    "DeveloperConnection": "Data Source=DESKTOP-ECILTJV;Initial Catalog=Clothing_Database_Developer;Integrated Security=True;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ClothingStoreApp/ClothingStore.Domain.Tests/ValueObjectTests/CartItemTests.cs
+++ b/ClothingStoreApp/ClothingStore.Domain.Tests/ValueObjectTests/CartItemTests.cs
@@ -1,5 +1,4 @@
 ﻿using ClothingStore.Domain.Entities;
-using ClothingStore.Domain.ValueObjects;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/ClothingStoreApp/ClothingStore.Domain/Entities/AvailableLocationBySize.cs
+++ b/ClothingStoreApp/ClothingStore.Domain/Entities/AvailableLocationBySize.cs
@@ -1,7 +1,5 @@
 ﻿namespace ClothingStore.Domain.Entities
 {
-    using ClothingStore.Domain.ValueObjects;
-
     public class AvailableLocationBySize
     {
         public Guid LocationId { get; set; }

--- a/ClothingStoreApp/ClothingStore.Domain/Entities/CartItem.cs
+++ b/ClothingStoreApp/ClothingStore.Domain/Entities/CartItem.cs
@@ -1,18 +1,19 @@
-﻿using ClothingStore.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ClothingStore.Domain.ValueObjects
+﻿namespace ClothingStore.Domain.Entities
 {
     public class CartItem
     {
+        public Guid CartItemId { get; private set; }
+        public Guid ShoppingCartId { get; private set; }
+        public ShoppingCart ShoppingCart { get; private set; }
+        public Guid ItemId { get; private set; }
         public Item Item { get; private set; }
         public int Quantity { get; private set; }
+
+        protected CartItem() { }
+
         public CartItem(Item item, int quantity)
         {
+            CartItemId = Guid.NewGuid();
             Item = item ?? throw new ArgumentNullException(nameof(item), "Item cannot be null");
             if (quantity <= 0)
                 throw new ArgumentException("Quantity must be greater than zero", nameof(quantity));

--- a/ClothingStoreApp/ClothingStore.Domain/Entities/Item.cs
+++ b/ClothingStoreApp/ClothingStore.Domain/Entities/Item.cs
@@ -1,6 +1,5 @@
 ﻿namespace ClothingStore.Domain.Entities
 {
-    using ClothingStore.Domain.Enumerators;
     using ClothingStore.Domain.Interfaces;
     using System.Text.RegularExpressions;
 

--- a/ClothingStoreApp/ClothingStore.Domain/Entities/ShoppingCart.cs
+++ b/ClothingStoreApp/ClothingStore.Domain/Entities/ShoppingCart.cs
@@ -1,7 +1,5 @@
 ﻿namespace ClothingStore.Domain.Entities
 {
-    using ClothingStore.Domain.ValueObjects;
-
     public class ShoppingCart
     {
         public Guid CartId { get; private set; }

--- a/ClothingStoreApp/ClothingStore.Domain/Entities/Size.cs
+++ b/ClothingStoreApp/ClothingStore.Domain/Entities/Size.cs
@@ -1,11 +1,13 @@
-﻿namespace ClothingStore.Domain.ValueObjects
+﻿namespace ClothingStore.Domain.Entities
 {
     public class Size
     {
+        public Guid SizeId { get; private set; }
         public string Letter { get; private set; }
-        public Size() { }
+        protected Size() { }
         public Size(string letter)
         {
+            SizeId = Guid.NewGuid();
             Letter = letter ?? throw new ArgumentNullException(nameof(letter), "Letter cannot be null");
         }
     }
@@ -18,6 +20,8 @@
         public float SleeveLength { get; private set; }
         public float SleeveCircumference { get; private set; }
         public float NeckCircumference { get; private set; }
+
+        protected ShirtSize() { }
         public ShirtSize(string letter, float length, float shoulderWidth, float chestWidth, float sleeveLength): base(letter)
         {
             if (length < 0 || shoulderWidth < 0 || chestWidth < 0 || sleeveLength < 0)
@@ -34,6 +38,7 @@
         public float Waist { get; private set; }
         public float Inseam { get; private set; }
         public float PantLegCircumference { get; private set; }
+        protected PantSize() { }
         public PantSize(string letter, float waist, float inseam) : base(letter)
         {
             if (waist < 0 || inseam < 0)
@@ -48,6 +53,8 @@
         public float Length { get; private set; }
         public float Width { get; private set; }
         public float? HeelHeight { get; private set; }
+
+        protected ShoeSize() { }
         public ShoeSize(string letter, float length, float width) : base(letter)
         {
             if (length < 0 || width < 0)
@@ -69,6 +76,8 @@
     public class HatSize : Size
     {
         public float Circumference { get; private set; }
+        //Maybe add a brim size or style in the future
+        protected HatSize() { }
         public HatSize(string letter, float circumference) : base(letter)
         {
             if (circumference < 0)
@@ -82,6 +91,7 @@
         public float Bust { get; private set; }
         public float Waist { get; private set; }
         public float Hip { get; private set; }
+        protected DressSize() { }
         public DressSize(string letter, float bust, float waist, float hip) : base(letter)
         {
             if (bust < 0 || waist < 0 || hip < 0)

--- a/ClothingStoreApp/ClothingStore.Domain/Entities/Tag.cs
+++ b/ClothingStoreApp/ClothingStore.Domain/Entities/Tag.cs
@@ -1,0 +1,25 @@
+﻿namespace ClothingStore.Domain.Entities
+{
+    public class Tag
+    {
+        public Guid TagId { get; private set; }
+        public Guid ItemId { get; private set; } // Foreign key for EF Core
+        public Item Item { get; private set; } // Navigation for EF Core
+
+        public string Name { get; private set; }
+        public int Ordinal { get; private set; }
+
+        protected Tag() { }
+
+        public Tag(string name, int ordinal)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Tag name cannot be null or empty", nameof(name));
+            if (ordinal < 0)
+                throw new ArgumentOutOfRangeException(nameof(ordinal), "Ordinal must be a non-negative integer");
+            TagId = Guid.NewGuid();
+            Name = name;
+            Ordinal = ordinal;
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Domain/Enumerators/TagEnum.cs
+++ b/ClothingStoreApp/ClothingStore.Domain/Enumerators/TagEnum.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ClothingStore.Domain.Enumerators
+﻿namespace ClothingStore.Domain.Enumerators
 {
-    public enum Tag
+    public enum TagEnum
     {
         Sweater,
         Shirt,

--- a/ClothingStoreApp/ClothingStore.Persistence/Class1.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace ClothingStore.Persistence
-{
-    public class Class1
-    {
-
-    }
-}

--- a/ClothingStoreApp/ClothingStore.Persistence/ClothingStore.Persistence.csproj
+++ b/ClothingStoreApp/ClothingStore.Persistence/ClothingStore.Persistence.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Configurations\" />
     <Folder Include="Migrations\" />
     <Folder Include="Repositories\" />
   </ItemGroup>

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/AvailableLocationsConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/AvailableLocationsConfigurations.cs
@@ -1,0 +1,39 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+namespace ClothingStore.Persistence.Configurations
+{
+    public class AvailableLocationsConfigurations: IEntityTypeConfiguration<AvailableLocationBySize>
+    {
+        public void Configure(EntityTypeBuilder<AvailableLocationBySize> builder)
+        {
+            builder.ToTable("AvailableLocations");
+            builder.HasKey(location => location.LocationId);
+            builder.Property(location => location.Size)
+                .IsRequired()
+                .HasMaxLength(12);
+            builder.Property(location => location.TotalStockOfSize)
+                .IsRequired()
+                .HasColumnType("int");
+
+            builder.OwnsOne(location => location.Size, sizeBuilder =>
+            {
+                sizeBuilder.Property(s => s.Letter)
+                    .HasColumnName("SizeLetter")
+                    .IsRequired()
+                    .HasMaxLength(12);
+            });
+            builder.HasOne(location => location.Variant)
+                .WithMany(variant => variant.AvailableLocations)
+                .HasForeignKey(location => location.VariantId)
+                .HasConstraintName("FK_Variants_AvailableLocations")
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(location => location.AvailableLocationsOfGivenSize)
+                .WithOne(stock => stock.LocationBySize)
+                .HasForeignKey(stock => stock.LocationBySizeId)
+                .HasConstraintName("FK_StockByLocation_AvailableLocations")
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/CartItemConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/CartItemConfigurations.cs
@@ -1,0 +1,25 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class CartItemConfigurations: IEntityTypeConfiguration<CartItem>
+    {
+        public void Configure(EntityTypeBuilder<CartItem> builder)
+        {
+            builder.ToTable("CartItems");
+            builder.HasKey(cartItem => cartItem.CartItemId);
+            builder.Property(cartItem => cartItem.Quantity)
+                .IsRequired()
+                .HasDefaultValue(1);
+            builder.HasOne(cartItem => cartItem.ShoppingCart)
+                .WithMany(cart => cart.Items)
+                .HasForeignKey(cartItem => cartItem.ShoppingCartId)
+                .HasConstraintName("FK_CartItems_ShoppingCarts")
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+    {
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/ItemConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/ItemConfigurations.cs
@@ -1,0 +1,50 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class ItemConfiguration : IEntityTypeConfiguration<Item>
+    {
+        public void Configure(EntityTypeBuilder<Item> builder)
+        {
+            builder.ToTable("Items");
+
+            builder.HasKey(item => item.ItemId);
+
+            builder.Property(item => item.Name)
+                .IsRequired();
+
+            builder.Property(item => item.Price)
+                .IsRequired()
+                .HasColumnType("decimal(18,2)");
+
+            builder.Property(item => item.Brand)
+                .IsRequired();
+
+            builder.Property(item => item.Collection)
+                .HasDefaultValue(string.Empty);
+
+            builder.Property(item => item.MaterialDistribution)
+                .IsRequired();
+
+            builder.HasMany(item => item.Variants)
+                .WithOne(variant => variant.Item)
+                .HasForeignKey(variant => variant.ItemId)
+                .HasConstraintName("FK_Items_Variants")
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(item => item.Tags)
+                .WithOne(tag => tag.Item)
+                .HasForeignKey(tag => tag.ItemId)
+                .HasConstraintName("FK_Items_Tags")
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(item => item.Reviews)
+                .WithOne(review => review.Item)
+                .HasForeignKey(review => review.ItemId)
+                .HasConstraintName("FK_Items_Reviews")
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/PhotoConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/PhotoConfigurations.cs
@@ -1,0 +1,25 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class PhotoConfigurations: IEntityTypeConfiguration<Photo>
+    {
+        public void Configure(EntityTypeBuilder<Photo> photoBuilder)
+        {
+            photoBuilder.ToTable("Photos");
+            photoBuilder.HasKey(photo => photo.PhotoId)
+                .HasName("PK_Photos");
+            photoBuilder.Property(photo => photo.UploadedAt)
+                .HasColumnType("datetimeoffset(0)")
+                .HasDefaultValueSql("SYSUTCDATETIME()");
+
+            photoBuilder.HasOne(photo => photo.Variant)
+                .WithMany(variant => variant.Gallery)
+                .HasForeignKey(photo => photo.VariantId)
+                .HasConstraintName("FK_Variants_Photos")
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/ReviewConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/ReviewConfigurations.cs
@@ -1,0 +1,24 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class ReviewConfigurations: IEntityTypeConfiguration<Review>
+    {
+        public void Configure(EntityTypeBuilder<Review> builder)
+        {
+            builder.ToTable("Reviews");
+            builder.HasKey(review => review.ReviewId)
+                .HasName("PK_Reviews");
+            
+            builder.HasOne(review => review.Item)
+                .WithMany(item => item.Reviews)
+                .HasForeignKey(review => review.ItemId)
+                .HasConstraintName("FK_Items_Reviews")
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }   
+    {
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/ShoppingCartConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/ShoppingCartConfigurations.cs
@@ -1,0 +1,30 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class ShoppingCartConfigurations: IEntityTypeConfiguration<ShoppingCart>
+    {
+        public void Configure(EntityTypeBuilder<ShoppingCart> builder)
+        {
+            builder.ToTable("ShoppingCarts");
+            builder.HasKey(cart => cart.CartId);
+            builder.Property(cart => cart.UserId)
+                .IsRequired();
+            builder.Property(cart => cart.CreatedAt)
+                .HasColumnType("datetimeoffset(0)")
+                .HasDefaultValueSql("SYSUTCDATETIME()");
+            //builder.HasOne(cart => cart.User)
+            //    .WithMany(user => user.ShoppingCarts)
+            //    .HasForeignKey(cart => cart.UserId)
+            //    .HasConstraintName("FK_Users_ShoppingCarts")
+            //    .OnDelete(DeleteBehavior.Cascade);
+            builder.HasMany(c => c.Items)
+               .WithOne(ci => ci.ShoppingCart)
+               .HasForeignKey(ci => ci.ShoppingCartId)
+                .HasConstraintName("FK_ShoppingCartItems_ShoppingCarts")
+               .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/SizeConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/SizeConfigurations.cs
@@ -1,0 +1,75 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class SizeConfigurations : IEntityTypeConfiguration<Size>
+    {
+        public void Configure(EntityTypeBuilder<Size> builder)
+        {
+            builder.ToTable("Sizes");
+            builder.HasKey(size => size.SizeId)
+                .HasName("PK_Sizes");
+            builder.Property(size => size.Letter)
+                .IsRequired()
+                .HasMaxLength(12);
+
+            builder.HasDiscriminator<string>("SizeType")
+                .HasValue<ShirtSize>("Shirt")
+                .HasValue<PantSize>("Pant")
+                .HasValue<ShoeSize>("Shoe")
+                .HasValue<DressSize>("Dress")
+                .HasValue<HatSize>("Hat");
+        }
+    }
+
+    public class ShirtSizeConfigurations : IEntityTypeConfiguration<ShirtSize>
+    {
+        public void Configure(EntityTypeBuilder<ShirtSize> builder)
+        {
+            builder.Property(s => s.Length).HasColumnName("Shirt_Length");
+            builder.Property(s => s.ShoulderWidth).HasColumnName("Shirt_ShoulderWidth");
+            builder.Property(s => s.ChestWidth).HasColumnName("Shirt_ChestWidth");
+            builder.Property(s => s.SleeveLength).HasColumnName("Shirt_SleeveLength");
+        }
+    }
+
+    public class PantSizeConfigurations : IEntityTypeConfiguration<PantSize>
+    {
+        public void Configure(EntityTypeBuilder<PantSize> builder)
+        {
+            builder.Property(s => s.Waist).HasColumnName("Pant_Waist");
+            builder.Property(s => s.Inseam).HasColumnName("Pant_Inseam");
+            builder.Property(s => s.PantLegCircumference).HasColumnName("Pant_PantLegCircumference");
+        }
+    }
+
+    public class ShoeSizeConfigurations : IEntityTypeConfiguration<ShoeSize>
+    {
+        public void Configure(EntityTypeBuilder<ShoeSize> builder)
+        {
+            builder.Property(s => s.Length).HasColumnName("Shoe_Length");
+            builder.Property(s => s.Width).HasColumnName("Shoe_Width");
+            builder.Property(s => s.HeelHeight).HasColumnName("Shoe_HeelHight");
+        }
+    }
+
+    public class HatSizeConfigurations : IEntityTypeConfiguration<HatSize>
+    {
+        public void Configure(EntityTypeBuilder<HatSize> builder)
+        {
+            builder.Property(s => s.Circumference).HasColumnName("Hat_Circumference");
+        }
+    }
+
+    public class DressSizeConfigurations : IEntityTypeConfiguration<DressSize>
+    {
+        public void Configure(EntityTypeBuilder<DressSize> builder)
+        {
+            builder.Property(s => s.Bust).HasColumnName("Dress_Bust");
+            builder.Property(s => s.Waist).HasColumnName("Dress_Waist");
+            builder.Property(s => s.Hip).HasColumnName("Dress_Hip");
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/StockByLocationConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/StockByLocationConfigurations.cs
@@ -1,0 +1,42 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+namespace ClothingStore.Persistence.Configurations
+{
+    public class StockByLocationConfigurations: IEntityTypeConfiguration<StockByLocation>
+    {
+        public void Configure(EntityTypeBuilder<StockByLocation> builder)
+        {
+            builder.ToTable("StocksByLocations");
+            builder.HasKey(stock => stock.StockId)
+                .HasName("PK_Stock");
+            builder.Property(stock => stock.Stock)
+                .IsRequired()
+                .HasColumnType("int")
+                .HasDefaultValue(0);
+            builder.OwnsOne(stock => stock.Location, locationBuilder => {
+                locationBuilder.Property(s => s.Latitude)
+                    .HasColumnName("Latitude")
+                    .IsRequired();
+
+                locationBuilder.Property(s => s.Longitude)
+                .HasColumnName("Longitude")
+                .IsRequired();
+
+                locationBuilder.Property(s => s.Address)
+                    .HasColumnName("Address")
+                    .HasMaxLength(255);
+
+                locationBuilder.ToTable("StocksByLocation");
+            });
+
+            builder.HasOne(stock => stock.LocationBySize)
+                .WithMany(location => location.AvailableLocationsOfGivenSize)
+                .HasForeignKey(stock => stock.LocationBySizeId)
+                .HasConstraintName("FK_StockByLocation_AvailableLocations")
+                .OnDelete(DeleteBehavior.Cascade);
+
+        }
+
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/TagConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/TagConfigurations.cs
@@ -1,0 +1,25 @@
+﻿using ClothingStore.Domain.Entities;
+using ClothingStore.Domain.Enumerators;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class TagConfigurations: IEntityTypeConfiguration<Tag>
+    {
+        public void Configure(EntityTypeBuilder<Tag> builder)
+        {
+            builder.ToTable("Tags");    
+            builder.HasKey(tag => tag.TagId)
+                .HasName("PK_Tags");
+            var seeds = Enum.GetValues<TagEnum>()
+            .Select((enumVal, idx) => new Tag(
+                name: enumVal.ToString(),
+                ordinal: (int)enumVal
+            ))
+            .ToArray();
+
+            builder.HasData(seeds);
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/UserConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/UserConfigurations.cs
@@ -1,0 +1,27 @@
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class UserConfigurations: IEntityTypeConfiguration<User>
+    {
+        public void Configure(EntityTypeBuilder<User> builder)
+        {
+            builder.ToTable("Users");
+            builder.HasKey(user => user.UserId)
+                .HasName("PK_Users");
+            builder.Property(user => user.Username)
+                .IsRequired()
+                .HasMaxLength(100);
+
+            //guest users only have one shopping cart
+
+            builder.HasOne(user => user.ShoppingCart)
+                .WithOne(cart => cart.User)
+                .HasForeignKey<ShoppingCart>(cart => cart.UserId)
+                .HasConstraintName("FK_Users_ShoppingCarts")
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Configurations/VariantConfigurations.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Configurations/VariantConfigurations.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ClothingStore.Persistence.Configurations
+{
+    public class VariantConfigurations: IEntityTypeConfiguration<Variant>
+    {
+        public void Configure(EntityTypeBuilder<Variant> builder)
+        {
+            builder.ToTable("Variants");
+            builder.HasKey(variant => variant.VariantId)
+                .HasName("PK_Variants");
+            builder.OwnsOne(v => v.Color, colorBuilder =>
+            {
+                colorBuilder.Property(c => c.Hexadecimal)
+                            .HasColumnName("ColorHex")
+                            .IsRequired();
+                colorBuilder.Property(c => c.Red)
+                            .HasColumnName("ColorRed")
+                            .IsRequired();
+                colorBuilder.Property(c => c.Green)
+                            .HasColumnName("ColorGreen")
+                            .IsRequired();
+                colorBuilder.Property(c => c.Blue)
+                            .HasColumnName("ColorBlue")
+                            .IsRequired();
+                colorBuilder.ToTable("Variants");
+            });
+            builder.HasOne(variant => variant.Item)
+                .WithMany(item => item.Variants)
+                .HasForeignKey(variant => variant.ItemId)
+                .HasConstraintName("FK_Items_Variants")
+                .OnDelete(DeleteBehavior.Cascade);
+            builder.HasMany(variant => variant.AvailableLocations)
+                .WithOne(location => location.Variant)
+                .HasForeignKey(location => location.VariantId)
+                .HasConstraintName("FK_Variants_AvailableLocations")
+                .OnDelete(DeleteBehavior.Cascade);
+            builder.HasMany(variant => variant.Gallery)
+                .WithOne(photo => photo.Variant)
+                .HasForeignKey(photo => photo.VariantId)
+                .HasConstraintName("FK_Variants_Photos")
+                .OnDelete(DeleteBehavior.Cascade);
+        }   
+    }
+}

--- a/ClothingStoreApp/ClothingStore.Persistence/Context/ApplicationDbContext.cs
+++ b/ClothingStoreApp/ClothingStore.Persistence/Context/ApplicationDbContext.cs
@@ -1,12 +1,47 @@
-﻿using System;
+﻿using ClothingStore.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace ClothingStore.Persistence.Context
 {
-    public class ApplicationDbContext
+    public class ApplicationDbContext: DbContext
     {
+        public DbSet<Item> Items { get; set; }
+        public DbSet<Variant> Variants { get; set; }
+        public DbSet<AvailableLocationBySize> AvailableLocations { get; set; }
+        public DbSet<StockByLocation> StocksByLocations { get; set; }
+        public DbSet<Photo> Photos { get; set; }
+        public DbSet<User> Users { get; set; }
+        public DbSet<ShoppingCart> ShoppingCarts { get; set; }
+        public DbSet<CartItem> CartItems { get; set; }
+        public DbSet<Tag> Tags { get; set; }
+        public DbSet<Review> Reviews { get; set; }
+
+
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
+            //base.OnModelCreating(modelBuilder);
+        }
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder.UseSqlServer("Data Source=DESKTOP-ECILTJV;Initial Catalog=Clothing_Database_Backup;Integrated Security=True;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False")
+                              .EnableSensitiveDataLogging();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Set up all configurations for entities via FluentAPI, and TPH inheritance configuration for the Size entity and it's subclasses. Set up the DbSets for entities and aggregates. Moved Size and CartItem from Value-Objects to Entities. Created Tag Entity for EFCore support. Added 2 connection strings to the main and the dev Databases. Created a fallback database on configuration.